### PR TITLE
Fix incorret signs when processing refunds / payments

### DIFF
--- a/importers/union_importer/cmb_credit.py
+++ b/importers/union_importer/cmb_credit.py
@@ -79,10 +79,11 @@ class CMBTransaction(Transaction):
                 '  ! Expenses:Uncategorized +{0.amount} CNY'
             ).format(self, self.beancount_account())
         else:
+            amount_abs = self.amount.strip('-')
             return (  # Refunds
-                '  {1} +{0.amount} CNY\n'
-                '  ! Expenses:Uncategorized -{0.amount} CNY'
-            ).format(self, self.beancount_account())
+                '  {1} +{0} CNY\n'
+                '  ! Expenses:Uncategorized -{0} CNY'
+            ).format(amount_abs, self.beancount_account())
 
     def beancount_repr(self):
         metadata = self.metadata()


### PR DESCRIPTION
Refunds / payments transactions in CMB credit card statements comes with negative signs (e.g. https://github.com/wzyboy/awesome-beancount/blob/37db3d59ba2d8ded28b2b8726b77a6693347951e/test_data/cmb_credit_cards.csv#L28 ) We should strip them first.
