### PR TITLE
Use settled date instead of trade date in beancount_repr

### DIFF
--- a/importers/union_importer/cmb_credit.py
+++ b/importers/union_importer/cmb_credit.py
@@ -61,8 +61,8 @@ class CMBTransaction(Transaction):
 
         metadata = (
             '  bill: "cmb credit"\n'
-            '  settled_date:"{0.settled_date}"\n'
-            '  card:"{1}"\n'
+            '  trade_date: "{0.trade_date}"\n'
+            '  card: "{1}"\n'
         ).format(self, card)
 
         if CMBCreditCard.show_linked:
@@ -90,10 +90,10 @@ class CMBTransaction(Transaction):
         flags = Account.beancount_flags
         postings = self.postings()
         return (
-            '{0.trade_date} {3} "{0.payee}" {0.comment}\n'
+            '{0.settled_date} {3} "{0.payee}" {0.comment}\n'
             '{1}'
             '{2}'
-            ).format(self, metadata, postings, flags)
+        ).format(self, metadata, postings, flags)
 
 
 def _map_card(last4):


### PR DESCRIPTION
Addressing https://github.com/wzyboy/awesome-beancount/issues/4 .

@sycx I do not import Alipay personally. Could you help testing if this breaks transaction merging? Thanks.
