### PR TITLE
Use settled date in beancount output

### DIFF
--- a/importers/union_importer/alipay.py
+++ b/importers/union_importer/alipay.py
@@ -212,7 +212,7 @@ class AliRecord(Transaction):
         )
 
         d = {}
-        d['date'] = self.trade_date
+        d['date'] = self.beancount_transaction_date()
         d['flag'] = Account.beancount_flags
         d['payee'] = self.payee
         d['narration'] = self.name
@@ -413,7 +413,7 @@ class AliAcclog(Transaction):
         )
 
         d = {}
-        d['date'] = self.trade_date
+        d['date'] = self.beancount_transaction_date()
         d['flag'] = Account.beancount_flags
         d['payee'] = self.chain_target() or ''
         d['narration'] = ''

--- a/importers/union_importer/alipay.py
+++ b/importers/union_importer/alipay.py
@@ -73,7 +73,7 @@ class Alipay(Account):
         # self.filter_results()
 
         self.merge_acclog_and_record()
-        self.transactions.sort(key=lambda t: t.trade_date)
+        self.transactions.sort(key=lambda t: t.sort_key())
 
     def current_csv_type(self, csv_data):
         reader = csv.reader(csv_data)

--- a/importers/union_importer/alipay.py
+++ b/importers/union_importer/alipay.py
@@ -218,6 +218,7 @@ class AliRecord(Transaction):
         d['narration'] = self.name
         d['metadata'] = (
             '  tradeNo:"{0.tradeNo}"\n'
+            '  trade_date:"{0.trade_date}"\n'
             '  bill:"alipay record"\n'
             ).format(self)
         if self.expenses:
@@ -369,6 +370,7 @@ class AliAcclog(Transaction):
         chain = self.chain_info()
         metadata = (
             '  tradeNo:"{0.tradeNo}"\n'
+            '  trade_date:"{0.trade_date}"\n'
             '  bill:"alipay acclog"\n'
             '  time:"{0.time}"\n'
             '  comment:"{0.comment}"\n'

--- a/importers/union_importer/base.py
+++ b/importers/union_importer/base.py
@@ -113,6 +113,7 @@ class Transaction(object):
     def __init__(self):
         super(Transaction, self).__init__()
         self.trade_date = None
+        self.settled_date = None
         self.income = None
         self.expenses = None
         self.amount = None
@@ -149,6 +150,14 @@ class Transaction(object):
     def beancount_account(self):
         return self.account.beancount_account
 
+    def beancount_transaction_date(self):
+        if self.settled_date:
+            return self.settled_date
+        if self.link and self.link[0].settled_date:
+            return self.link[0].settled_date
+
+        return self.trade_date
+
     def beancount_repr(self):
         amount = 0
         if len(self.income) > 0:
@@ -157,11 +166,12 @@ class Transaction(object):
             amount = self.expenses
 
         beancount_account = "Liabilities:CMB:CreditCards"
+        date = self.beancount_transaction_date()
         return (
-            '{0.trade_date} ! "{0.payee}" {0.comment}\n'
+            '{3} ! "{0.payee}" {0.comment}\n'
             ' {1} {2} CNY\n'
             ' ! Expenses:Uncategorized'
-            ).format(self, beancount_account, amount)
+            ).format(self, beancount_account, amount, date)
 
     def __repr__(self):
         rep = (

--- a/importers/union_importer/base.py
+++ b/importers/union_importer/base.py
@@ -146,6 +146,9 @@ class Transaction(object):
         self.link.append(other)
         other.link.append(self)
 
+    def sort_key(self):
+        return self.beancount_transaction_date()
+
     # output
     def beancount_account(self):
         return self.account.beancount_account

--- a/importers/union_importer/cmb_credit.py
+++ b/importers/union_importer/cmb_credit.py
@@ -61,7 +61,7 @@ class CMBTransaction(Transaction):
 
         metadata = (
             '  bill: "cmb credit"\n'
-            '  settled_date:"{0.settled_date}"\n'
+            '  trade_date:"{0.trade_date}"\n'
             '  card:"{1}"\n'
         ).format(self, card)
 
@@ -90,7 +90,7 @@ class CMBTransaction(Transaction):
         flags = Account.beancount_flags
         postings = self.postings()
         return (
-            '{0.trade_date} {3} "{0.payee}" {0.comment}\n'
+            '{0.settled_date} {3} "{0.payee}" {0.comment}\n'
             '{1}'
             '{2}'
             ).format(self, metadata, postings, flags)

--- a/importers/union_importer/cmb_debit.py
+++ b/importers/union_importer/cmb_debit.py
@@ -99,14 +99,15 @@ class CMBDebitTransaction(Transaction):
             ).format(self, self.beancount_account())
 
     def beancount_repr(self):
+        date = self.beancount_transaction_date()
         return (
-            '{0.trade_date} {2} "" "{0.comment}"\n'
+            '{3} {2} "" "{0.comment}"\n'
             '  bill:"cmb debit"\n'
             '  time:"{0.trade_time}"\n'
             '  type:"{0.category}"\n'
             '  balance:"{0.balance}"\n'
             '{1}'
-            ).format(self, self.beancount_postings(), Account.beancount_flags)
+            ).format(self, self.beancount_postings(), Account.beancount_flags, date)
 
 
 def main():

--- a/importers/union_importer/cmb_debit.py
+++ b/importers/union_importer/cmb_debit.py
@@ -28,7 +28,7 @@ class CMBDebitCard(Account):
             self.parser_csv(csv_data)
             csv_data.close()
 
-        self.transactions.sort(key=lambda t: t.trade_date)
+        self.transactions.sort(key=lambda t: t.sort_key())
 
     def parser_row(self, row):
         if row[0].strip().startswith('#'):

--- a/importers/union_importer/cmb_debit.py
+++ b/importers/union_importer/cmb_debit.py
@@ -103,6 +103,7 @@ class CMBDebitTransaction(Transaction):
         return (
             '{3} {2} "" "{0.comment}"\n'
             '  bill:"cmb debit"\n'
+            '  trade_date:"{0.trade_date}"\n'
             '  time:"{0.trade_time}"\n'
             '  type:"{0.category}"\n'
             '  balance:"{0.balance}"\n'

--- a/importers/union_importer/union_importer.py
+++ b/importers/union_importer/union_importer.py
@@ -77,7 +77,7 @@ class Resolver(object):
         remain = [x for x in alltransactions if x not in exclude]
 
         final = matched + remain
-        final.sort(key=lambda t: t.trade_date)
+        final.sort(key=lambda t: t.sort_key())
         return final
 
 


### PR DESCRIPTION
Changes:
- Use settled date as transaction date in beancount  output
- Add trade_date in metadata
- Sort by settled date
