### PR TITLE
using explicit codec 'utf-8'

### DIFF
--- a/importers/cmb_credit_cards.py
+++ b/importers/cmb_credit_cards.py
@@ -68,7 +68,7 @@ def print_beans(beans, filename=None):
 def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
-        'csv', nargs='?', type=argparse.FileType('r'), default=sys.stdin,
+        'csv', nargs='?', type=argparse.FileType(mode='r', encoding='utf-8'), default=sys.stdin,
         help='CSV file of China Merchants Bank credit card bill'
     )
     argparser.add_argument('-p', '--pass', dest='_pass', action='store_true')

--- a/importers/cmb_debit_cards.py
+++ b/importers/cmb_debit_cards.py
@@ -71,7 +71,7 @@ def print_beans(beans, filename=None):
 def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument(
-        'csv', nargs='?', type=argparse.FileType('r'), default=sys.stdin,
+        'csv', nargs='?', type=argparse.FileType(mode='r', encoding='utf-8'), default=sys.stdin,
         help='CSV file of China Merchants Bank debit card data'
     )
     argparser.add_argument('-p', '--pass', dest='_pass', action='store_true')


### PR DESCRIPTION
Windows use 'gbk' codec by default, causing following error:

```
UnicodeEncodeError: 'gbk' codec can't encode character '\xa0' in position ...
```
